### PR TITLE
#17 PolygonFactory 구현 및 테스트

### DIFF
--- a/src/main/java/io/wisoft/aoiandregionmatcherv1/dto/Point.java
+++ b/src/main/java/io/wisoft/aoiandregionmatcherv1/dto/Point.java
@@ -1,0 +1,13 @@
+package io.wisoft.aoiandregionmatcherv1.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class Point {
+
+  private final double x;
+  private final double y;
+
+}

--- a/src/main/java/io/wisoft/aoiandregionmatcherv1/entity/factory/PolygonFactory.java
+++ b/src/main/java/io/wisoft/aoiandregionmatcherv1/entity/factory/PolygonFactory.java
@@ -1,0 +1,29 @@
+package io.wisoft.aoiandregionmatcherv1.entity.factory;
+
+import io.wisoft.aoiandregionmatcherv1.dto.Point;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class PolygonFactory {
+  private static final GeometryFactory geometryFactory = new GeometryFactory();
+
+  public static Polygon createPolygon(List<Point> points) {
+    try {
+      final LinearRing linear = geometryFactory.createLinearRing(points
+          .stream()
+          .map((point) -> new Coordinate(point.getX(), point.getY())).toArray(Coordinate[]::new));
+      return new Polygon(linear, null, geometryFactory);
+    } catch (IllegalArgumentException exception) {
+      throw new RingNotClosedException();
+    }
+  }
+
+}

--- a/src/main/java/io/wisoft/aoiandregionmatcherv1/entity/factory/RingNotClosedException.java
+++ b/src/main/java/io/wisoft/aoiandregionmatcherv1/entity/factory/RingNotClosedException.java
@@ -1,0 +1,4 @@
+package io.wisoft.aoiandregionmatcherv1.entity.factory;
+
+public class RingNotClosedException extends RuntimeException {
+}

--- a/src/test/java/io/wisoft/aoiandregionmatcherv1/entity/factory/PolygonFactoryTest.java
+++ b/src/test/java/io/wisoft/aoiandregionmatcherv1/entity/factory/PolygonFactoryTest.java
@@ -1,0 +1,42 @@
+package io.wisoft.aoiandregionmatcherv1.entity.factory;
+
+import io.wisoft.aoiandregionmatcherv1.dto.Point;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Polygon;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class PolygonFactoryTest {
+
+  @Test
+  void createPolygonTest() {
+    final Point point1 = new Point(1, 2);
+    final Point point2 = new Point(3, 4);
+    final Point point3 = new Point(1, 2);
+    final List<Point> points = List.of(point1, point2, point3);
+
+    final Polygon polygon = PolygonFactory.createPolygon(points);
+
+    final Coordinate[] coordinates = polygon.getCoordinates();
+
+    for (int i = 0; i < points.size(); i++) {
+      assertThat(coordinates[i].x).isEqualTo(points.get(i).getX());
+      assertThat(coordinates[i].y).isEqualTo(points.get(i).getY());
+    }
+  }
+
+  @Test
+  void failToCreatePolygonByRingNotClosed() {
+    final Point point1 = new Point(1, 2);
+    final Point point2 = new Point(3, 4);
+    final List<Point> points = List.of(point1, point2);
+
+    assertThatExceptionOfType(RingNotClosedException.class)
+        .isThrownBy(() -> PolygonFactory.createPolygon(points));
+  }
+
+}


### PR DESCRIPTION
* s/main/j/i/w/a/dto/Point.java
  * x,y 좌표를 저장하는 DTO 클래스 구현
* s/main/j/i/w/a/entity/factory/PolygonFactory.java
  * Polygon을 생성하는 팩토리 클래스 구현
* s/main/j/i/w/a/entity/factory/RingNotClosedException.java
  * 좌표의 시작과 끝이 맞닿지 않아, 링을 구성하지 못하여 발생하는
    예외 구현
* s/test/j/i/w/a/entity/factory/PolygonFactoryTest.java
  * PolygonFactory의 Polygon 생성 성공 테스트 구현
  * PolygonFactory의 Polygon 생성 실패 테스트 구현

Resolves: #17
See also: None