### PR TITLE
#5 행정 지역의 이름과 전체 지리 정보 저장 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux:2.6.7'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation:2.6.7'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.6.7'
     implementation 'org.hibernate:hibernate-spatial:5.6.8.Final'

--- a/src/main/java/io/wisoft/aoiandregionmatcherv1/controller/RegionController.java
+++ b/src/main/java/io/wisoft/aoiandregionmatcherv1/controller/RegionController.java
@@ -1,0 +1,28 @@
+package io.wisoft.aoiandregionmatcherv1.controller;
+
+import io.wisoft.aoiandregionmatcherv1.dto.RegisterRegionRequest;
+import io.wisoft.aoiandregionmatcherv1.dto.RegisterRegionResponse;
+import io.wisoft.aoiandregionmatcherv1.service.RegionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/regions")
+@RequiredArgsConstructor
+public class RegionController {
+
+  private final RegionService regionService;
+
+  @PostMapping
+  public RegisterRegionResponse register(@RequestBody @Valid RegisterRegionRequest request) {
+    final Integer regionId = regionService.register(request);
+    return new RegisterRegionResponse(regionId);
+  }
+
+
+}

--- a/src/main/java/io/wisoft/aoiandregionmatcherv1/dto/RegisterRegionRequest.java
+++ b/src/main/java/io/wisoft/aoiandregionmatcherv1/dto/RegisterRegionRequest.java
@@ -3,13 +3,21 @@ package io.wisoft.aoiandregionmatcherv1.dto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Getter
 @RequiredArgsConstructor
 public class RegisterRegionRequest {
 
+  @NotNull
+  @NotBlank
   private final String name;
+
+  @NotNull
+  @NotEmpty
   private final List<Point> area;
 
 }

--- a/src/main/java/io/wisoft/aoiandregionmatcherv1/dto/RegisterRegionResponse.java
+++ b/src/main/java/io/wisoft/aoiandregionmatcherv1/dto/RegisterRegionResponse.java
@@ -1,0 +1,14 @@
+package io.wisoft.aoiandregionmatcherv1.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterRegionResponse {
+
+  private Integer id;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.spatial.dialect.postgis.PostgisDialect
 
   datasource:
     url: jdbc:postgresql://localhost:5432/postgres

--- a/src/test/api/api.http
+++ b/src/test/api/api.http
@@ -1,0 +1,22 @@
+POST http://localhost:8080/regions
+Content-Type: application/json
+
+{
+  "name": "행정구역",
+  "area": [
+    {
+      "x": 1,
+      "y": 2
+    },
+    {
+      "x": 2,
+      "y": 3
+    },
+    {
+      "x": 1,
+      "y": 2
+    }
+  ]
+}
+
+###

--- a/src/test/java/io/wisoft/aoiandregionmatcherv1/controller/RegionControllerTest.java
+++ b/src/test/java/io/wisoft/aoiandregionmatcherv1/controller/RegionControllerTest.java
@@ -1,0 +1,45 @@
+package io.wisoft.aoiandregionmatcherv1.controller;
+
+import io.wisoft.aoiandregionmatcherv1.dto.Point;
+import io.wisoft.aoiandregionmatcherv1.dto.RegisterRegionRequest;
+import io.wisoft.aoiandregionmatcherv1.dto.RegisterRegionResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class RegionControllerTest {
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @Test
+  void registerRegionTest() {
+    final String name = "행정구역";
+    final List<Point> area = List.of(new Point(1, 2), new Point(3, 4), new Point(1, 2));
+    final RegisterRegionRequest request = new RegisterRegionRequest(name, area);
+
+    this.webTestClient
+        .post()
+        .uri("/regions")
+        .accept(APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus().is2xxSuccessful()
+        .expectBody(new ParameterizedTypeReference<RegisterRegionResponse>() {
+        })
+        .consumeWith(response -> {
+          final RegisterRegionResponse responseBody = response.getResponseBody();
+          assertThat(responseBody).isNotNull();
+        });
+  }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.spatial.dialect.postgis.PostgisDialect
 
   datasource:
     url: jdbc:postgresql://localhost:5432/postgres


### PR DESCRIPTION
* s/main/j/i/w/a/controller/RegionController.java
  * RegionController의 등록 기능 구현
* s/main/j/i/w/a/dto/RegisterRegionResponse.java
  * Region 등록의 응답 DTO 구현
* s/main/j/i/w/a/dto/RegisterRegionRequest.java
  * Region 등록의 요청 DTO 수정
    * 이름이 존재하지 않거나 비어있으면 400 응답
* s/main/resources/application.yml
  * PostgisDialect 추가

* src/test/java/io/wisoft/aoiandregionmatcherv1/controller/RegionControllerTest.java
  * WebClient를 활용한 Region 등록 기능 통합 테스트
* src/test/api/api.http
  * HTTP 파일을 활용한 Region 등록 기능 통합 테스트
* src/test/resources/application.yml
  * PostgisDialect 추가

* build.gradle
  * 통합 테스트를 위한 WebFlux 의존 추가
  * HTTP Request의 Body를 검증하기 위한 Validation 의존 추가

Resolves: #5
See also: None