### PR TITLE
#6 관심 지역의 이름과 전체 지리 정보 저장 API 구현

### DIFF
--- a/src/main/java/io/wisoft/aoiandregionmatcherv1/controller/AoiController.java
+++ b/src/main/java/io/wisoft/aoiandregionmatcherv1/controller/AoiController.java
@@ -1,0 +1,28 @@
+package io.wisoft.aoiandregionmatcherv1.controller;
+
+import io.wisoft.aoiandregionmatcherv1.dto.RegisterAoiRequest;
+import io.wisoft.aoiandregionmatcherv1.dto.RegisterAoiResponse;
+import io.wisoft.aoiandregionmatcherv1.service.AoiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/aois")
+@RequiredArgsConstructor
+public class AoiController {
+
+  private final AoiService aoiService;
+
+  @PostMapping
+  public RegisterAoiResponse register(@RequestBody @Valid RegisterAoiRequest request) {
+    final Integer aoiId = aoiService.register(request);
+    return new RegisterAoiResponse(aoiId);
+  }
+
+
+}

--- a/src/main/java/io/wisoft/aoiandregionmatcherv1/dto/RegisterAoiResponse.java
+++ b/src/main/java/io/wisoft/aoiandregionmatcherv1/dto/RegisterAoiResponse.java
@@ -1,0 +1,14 @@
+package io.wisoft.aoiandregionmatcherv1.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterAoiResponse {
+
+  private Integer id;
+
+}

--- a/src/test/api/api.http
+++ b/src/test/api/api.http
@@ -20,3 +20,26 @@ Content-Type: application/json
 }
 
 ###
+
+POST http://localhost:8080/aois
+Content-Type: application/json
+
+{
+  "name": "관심구역",
+  "area": [
+    {
+      "x": 1,
+      "y": 2
+    },
+    {
+      "x": 2,
+      "y": 3
+    },
+    {
+      "x": 1,
+      "y": 2
+    }
+  ]
+}
+
+###

--- a/src/test/java/io/wisoft/aoiandregionmatcherv1/controller/AoiControllerTest.java
+++ b/src/test/java/io/wisoft/aoiandregionmatcherv1/controller/AoiControllerTest.java
@@ -1,0 +1,45 @@
+package io.wisoft.aoiandregionmatcherv1.controller;
+
+import io.wisoft.aoiandregionmatcherv1.dto.Point;
+import io.wisoft.aoiandregionmatcherv1.dto.RegisterAoiRequest;
+import io.wisoft.aoiandregionmatcherv1.dto.RegisterAoiResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class AoiControllerTest {
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @Test
+  void registerAoiTest() {
+    final String name = "관심구역";
+    final List<Point> area = List.of(new Point(1, 2), new Point(3, 4), new Point(1, 2));
+    final RegisterAoiRequest request = new RegisterAoiRequest(name, area);
+
+    this.webTestClient
+        .post()
+        .uri("/aois")
+        .accept(APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus().is2xxSuccessful()
+        .expectBody(new ParameterizedTypeReference<RegisterAoiResponse>() {
+        })
+        .consumeWith(response -> {
+          final RegisterAoiResponse responseBody = response.getResponseBody();
+          assertThat(responseBody).isNotNull();
+        });
+  }
+
+}


### PR DESCRIPTION
* s/main/j/i/w/a/controller/AoiController.java
  * AoiController의 등록 기능 구현
* s/main/j/i/w/a/dto/RegisterAoiResponse.java
  * Aoi 등록의 응답 DTO 구현
* s/test/j/i/w/a/controller/AoiControllerTest.java
  * WebClient를 활용한 Aoi 등록 기능 통합 테스트
* s/test/api/api.http
  * HTTP 파일을 활용한 Aoi 등록 기능 통합 테스트

Resolves: #6
See also: None